### PR TITLE
📦 Bump npm:axios:1.3.4 to 1.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     }
   ],
   "dependencies": {
-    "axios": "^1.3.4",
+    "axios": "^1.11.0",
     "form-data": "4.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Lineaje has automatically created this pull request to resolve the following CVEs:

| CVE ID  | Severity | Description       |
|-------|-----|-----------|
| CVE-2024-39338 | High | axios 1.7.2 allows SSRF via unexpected behavior where requests for path relative URLs get processed as protocol relative URLs. |
| CVE-2025-27152 | High | axios is a promise based HTTP client for the browser and node.js. The issue occurs when passing absolute URLs rather than protocol-relative URLs to axios. Even if ⁠baseURL is set, axios sends the request to the specified absolute URL, potentially causing SSRF and credential leakage. This issue impacts both server-side and client-side usage of axios. This issue is fixed in 1.8.2. |
| CVE-2023-45857 | Medium | An issue discovered in Axios 1.5.1 inadvertently reveals the confidential XSRF-TOKEN stored in cookies by including it in the HTTP header X-XSRF-TOKEN for every request made to any host allowing attackers to view sensitive information. |


You can merge this PR once the tests pass and the changes are reviewed.

Thank you for reviewing the update! :rocket: